### PR TITLE
Add configurable diff truncation limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # llm-commit
 
-[LLM](https://llm.datasette.io/) plugin for generating Git commit messages using an LLM.  
+[LLM](https://llm.datasette.io/) plugin for generating Git commit messages using an LLM.
 
 ## Installation
 
 Install this plugin in the same environment as LLM.
+
 ```bash
 llm install llm-commit
 ```
@@ -14,6 +15,7 @@ llm install llm-commit
 The plugin adds a new command, `llm commit`. This command generates a commit message from your staged Git diff and then commits the changes.
 
 For example, to generate and commit changes
+
 ```bash
 # Stage your changes first
 git add .
@@ -23,17 +25,23 @@ llm commit
 ```
 
 You can also customize options:
+
 ```bash
 # Skip the confirmation prompt
 llm commit --yes
 
 # Use a different LLM model, adjust max tokens, or change the temperature
 llm commit --model gpt-4 --max-tokens 150 --temperature 0.8
+
+# Control diff truncation behavior
+llm commit --truncation-limit 2000  # Truncate diffs longer than 2000 characters
+llm commit --no-truncation         # Never truncate diffs (use with caution on large changes)
 ```
 
 ## Development
 
 To set up this plugin locally, first check out the code. Then create a new virtual environment:
+
 ```bash
 cd llm-commit
 python3 -m venv venv
@@ -41,11 +49,13 @@ source venv/bin/activate
 ```
 
 Now install the dependencies and test dependencies:
+
 ```bash
 pip install -e '.[test]'
 ```
 
 To run the tests:
+
 ```bash
 python -m pytest
 ```

--- a/llm_commit.py
+++ b/llm_commit.py
@@ -96,7 +96,7 @@ def register_commands(cli):
     @click.option("--max-tokens", type=int, default=100, help="Max tokens")
     @click.option("--temperature", type=float, default=0.3, help="Temperature")
     @click.option("--truncation-limit", type=int, default=4000, help="Character limit for diff truncation")
-    @click.option("--no-truncation", is_flag=True, help="Disable diff truncation. Can cause issues with large diffs.")
+    @click.option("--no-truncation", is_flag=True, help="Disable diff truncation. Can cause issues with large diffs")
     def commit_cmd(yes, model, max_tokens, temperature, truncation_limit, no_truncation):
         if not is_git_repo():
             logging.error("Not a Git repository.")


### PR DESCRIPTION
Many custom LLMs allow wide token input windows while maintaining low price (for example, Gemini Flash v2), so it can be useful to provide users with a customizable option to modify the truncation limit. 