### PR TITLE
Enhance commit message generation with commit message styles

### DIFF
--- a/llm_commit.py
+++ b/llm_commit.py
@@ -35,7 +35,7 @@ def get_staged_diff(truncation_limit=4000, no_truncation=False):
         diff = diff[:truncation_limit] + "\n[Truncated]"
     return diff
 
-def generate_commit_message(diff, commit_style, model=None, max_tokens=100, temperature=0.7):
+def generate_commit_message(diff, commit_style=None, model=None, max_tokens=100, temperature=0.7):
     import llm
     from llm.cli import get_default_model
     from llm import get_key


### PR DESCRIPTION
Resolves issue #2 

## Summary

### Introduce command-line options

* `--semantic` → Enforce Semantic Commit Messages (e.g., feat(parser): add JSON support).
* `--conventional` → Enforce Conventional Commits (slightly different syntax) with optional BREAKING CHANGE warnings in description.

By default it follows the previous commit message style.

### Updated system prompt

- Instruct the model to focus on the added value of changes (meta-analysis).
- Highlight key changes while avoiding paraphrasing.
- Forbid syntax markers or tags outside of the specified commit style.


