### PR TITLE
Return to default llm logging.

### DIFF
--- a/llm_commit.py
+++ b/llm_commit.py
@@ -6,8 +6,6 @@ import subprocess
 from pathlib import Path
 import llm
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
-
 def run_git(cmd):
     try:
         return subprocess.run(cmd, capture_output=True, text=True, check=True).stdout.strip()


### PR DESCRIPTION
llm-commit currently turns on INFO logging for all of llm, even when it's not being used. This removes this additional logging.